### PR TITLE
Feature/add careers section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ Icon
 .vs/VSWorkspaceState.json
 .vs/slnx.sqlite
 .vs/vnext-com-au/v16/.suo
+
+# Don't think we want to add this
+Gemfile.lock

--- a/_config.yml
+++ b/_config.yml
@@ -48,3 +48,36 @@ address:
 # Build settings
 markdown: kramdown
 permalink: pretty
+
+#---- Generate Career Postings
+#
+# See https://github.com/avillafiorita/jekyll-datapage_gen
+#
+
+page_gen:
+  # - index_files: <<true or false> (optional) to generate named folder
+  #   data: <<name of the data file to read (YAML, JSON, or CSV)>>
+  #         Use the full path if your data is structured in a hierarchy. 
+  #         For instance: hierarchy.people will loop over a variable people in the _data/hierarchy.yml file
+  #   template: <<name of the template to use to generate the page>>
+  #   name: <<the name of a field containing unique ID used to generate the filename>>
+  #   name_expr : is an optional Ruby expression used to generate a filename. 
+  #               Can reference fields of the data being read using the record hash
+  #               (e.g., record['first_name'] + "_" + record['last_name']) 
+  #               Optional: if set, this overrides name
+  #   dir: <<directory in which files are to be generated>>
+  #   extension : the extension of the generated file. Optional: defaults to ".html"
+  #   filter : is a property of each data record that must return a true-ish value 
+  #            for the record to be included in the list of files to be generated. 
+  #            Optional: if not specified, all records from the dataset are included
+  # filter_condition : is a string containing a Ruby expression which evaluates to a true-ish value. 
+  #                    Can reference fields of the data being read using the record hash 
+  #                    (e.g., record['author'] == 'George Orwell'). 
+  #                    Optional: if not specified, all records from the dataset are included (see also filter).
+
+  - index_files: false
+    data: 'careers'
+    template: 'careers'
+    name: 'generated_page_name'
+    dir: 'careers'
+    filter: active

--- a/_data/careers.yml
+++ b/_data/careers.yml
@@ -1,0 +1,39 @@
+- display_name: Azure Engineer
+  generated_page_name: azure-engineer
+  active: true
+  long_desc: We are looking for a hands-on Azure engineer to join our team and help us deliver cutting-edge projects and drive real outcomes for our customers. Successful applicants will have the following skills and capabilities
+  keys:
+  - Solid understanding of cloud architecture, ideally demonstrated with Microsoft Azure.
+  - Solid understanding of SDLC and DevOps best practices including CI/CD and Infrastructure as Code. 
+  - Strong customer-facing skills to manage business and technical conversations. 
+  - Experience in at least two of the following languages C#, Python, and JavaScript  
+  - Passion for Data & AI projects. Previous experience with Data / ML projects is advantageous but not mandatory. 
+  - Previous consulting experience is highly desirable but not mandatory. 
+  - We value understanding, communication, passion, and aptitude for learning over years of experience. 
+  - Contract and permanent opportunities available
+  # maybe use something like this later?
+  tags:
+  - azure
+  - devops
+
+# -----------------------------------------
+# To add another, just add to collection,
+# For example:
+# -----------------------------------------
+
+# - display_name: AWS Engineer
+#   generated_page_name: aws-engineer
+#   active: true
+#   long_desc: We are looking for a hands-on AWS engineer to join our team and help us deliver cutting-edge projects and drive real outcomes for our customers. Successful applicants will have the following skills and capabilities
+#   keys:
+#   - Solid understanding of cloud architecture, ideally demonstrated with AWS.
+#   - Solid understanding of SDLC and DevOps best practices including CI/CD and Infrastructure as Code. 
+#   - Strong customer-facing skills to manage business and technical conversations. 
+#   - Experience in at least two of the following languages: C#, Python, and JavaScript 
+#   - Passion for Data & AI projects. Previous experience with Data / ML projects is advantageous but not mandatory. 
+#   - Previous consulting experience is highly desirable but not mandatory. 
+#   - We value understanding, communication, passion, and aptitude for learning over years of experience. 
+#   - Contract and permanent opportunities available
+# maybe use something like this later?
+#   - aws
+#   - devops

--- a/_includes/careers-contact-us.html
+++ b/_includes/careers-contact-us.html
@@ -1,0 +1,8 @@
+        <div class="row">
+            <div class="col-lg-12">
+                <h4 class="careers-heading">Interested?</h4>
+                <ul>
+                    <li>Please reach us at <a href="mailto:jobs@vnext.com.au?subject=website_jobs_enquiry">jobs@vnext.com.au</a></li>
+                </ul>
+            </div>
+        </div>

--- a/_includes/careers-home.html
+++ b/_includes/careers-home.html
@@ -1,0 +1,17 @@
+    <!-- Careers Section on main page -->
+    <section id="careers">
+        <div class="container">
+            <div class="row">
+                <div class="col-lg-12 text-center">
+                    <h2 class="section-heading">Careers</h2>                    
+                </div>
+            </div>
+
+            {% include careers-why-vnext.html %}
+
+            {% include careers-open.html %}
+
+            {% include careers-contact-us.html %}
+
+        </div>
+    </section>

--- a/_includes/careers-open.html
+++ b/_includes/careers-open.html
@@ -1,0 +1,12 @@
+            <div class="row">
+                <div class="col-lg-12">
+                    <h4 class="careers-heading">Open Roles</h4>
+                    <ul>
+                        {% for job in site.data.careers %}
+                            {% if job.active == true %}
+                                <li><a href="careers/{{ job.generated_page_name }}">{{ job.display_name }}</a></li>
+                            {% endif %}
+                        {% endfor %}
+                    </ul>
+                </div>
+            </div>

--- a/_includes/careers-page-body.html
+++ b/_includes/careers-page-body.html
@@ -1,0 +1,70 @@
+        
+
+<!-- Career Detail Page (data from _layouts/careers.html) -->
+<section id="careers">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-12 text-center">
+                <h2 class="section-heading">Careers</h2>                    
+            </div>
+        </div>
+
+        <div class="row text-center">
+                <div class="col-lg-12 text-center">
+                <span class="fa-stack fa-4x">
+                    <i class="fa fa-circle fa-stack-2x text-primary"></i>
+                    <i class="fa fa-cloud fa-stack-1x fa-inverse"></i>
+                </span>
+                <h4 class="careers-heading">{{ page.display_name }}</h4>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-lg-12">
+                <h4 class="careers-heading">About Us</h3>
+                <p class="text-muted">
+                    vNEXT is an exciting new consultancy company focused on augmenting human capabilities with AI. We help organisations innovate faster and be more competitive by combining Cloud, DevOps, Data, and AI. We take pride in having the best technologists in the industry. But it's not just about the technology. It’s also about working with our customers to find the right solutions to the right problems.
+                </p>                    
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-lg-12">
+                <h4 class="careers-heading">About our people</h3>
+                <p class="text-muted">
+                        We put people first in everything we do. Successful teams, projects, and partnerships depend on great people and great relationships. We hire people we want to work with, and people you will want to work with too.
+                </p>                    
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-lg-12">
+                <h4 class="careers-heading">About the role</h4>
+                <h5 class="careers-heading">{{ page.display_name }}</h5>
+                <p class="text-muted">
+                    {{ page.long_desc }}
+                </p>  
+                <ul>
+                    {% for key in page.keys %}
+                        <li>{{ key }}</a></li>
+                    {% endfor %}
+                </ul>
+            </div>
+        </div>
+
+        {% include careers-why-vnext.html %}
+
+        {% include careers-contact-us.html %}
+
+        <div class="row">
+            <div class="col-lg-12">
+                <h4 class="careers-heading">Other Careers</h4>
+                <ul>
+                    <li>Back to <a href="/index.html#careers">more careers</a></li>
+                </ul>
+            </div>
+        </div>
+
+
+    </div>
+</section>        

--- a/_includes/careers-page-header.html
+++ b/_includes/careers-page-header.html
@@ -1,0 +1,52 @@
+<!-- Navigation -->
+<nav class="navbar navbar-default navbar-fixed-top">
+    <div class="container">
+        <!-- Brand and toggle get grouped for better mobile display -->
+        <div class="navbar-header page-scroll">
+            <button type="button" class="navbar-toggle" data-toggle="collapse"
+                data-target="#bs-example-navbar-collapse-1">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </button>
+            <a class="navbar-brand page-scroll logo" href="/">{{site.title}}</a>
+        </div>
+
+        <!-- Collect the nav links, forms, and other content for toggling -->
+        <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+            <ul class="nav navbar-nav navbar-right">
+                <li class="hidden">
+                    <a href="#page-top"></a>
+                </li>
+                <li>
+                    <a class="page-scroll" href="/index.html#services">WHAT WE DO</a>
+                </li>
+                <!-- <li>
+                        <a class="page-scroll" href="#portfolio">Portfolio</a>
+                    </li> -->
+                <li>
+                    <a class="page-scroll" href="/index.html#careers">CAREERS</a>
+                </li>
+                <li>
+                    <a class="page-scroll" href="/index.html#team">OUR TEAM</a>
+                </li>
+                <li>
+                    <a class="page-scroll" href="/index.html#contact">CONTACT US</a>
+                </li>
+            </ul>
+        </div>
+        <!-- /.navbar-collapse -->
+    </div>
+    <!-- /.container-fluid -->
+</nav>
+
+<!-- Header -->
+<header>
+    <div class="container">
+        <div class="intro-text">
+            <div class="intro-lead-in">Join us as our next</div>
+            <div class="intro-heading">{{ page.display_name }}</div>
+        </div>
+    </div>
+</header>

--- a/_includes/careers-why-vnext.html
+++ b/_includes/careers-why-vnext.html
@@ -1,18 +1,9 @@
-<!-- Careers Section -->
-    <section id="careers">
-        <div class="container">
-            <div class="row">
-                <div class="col-lg-12 text-center">
-                    <h2 class="section-heading">Careers</h2>
-                    <h3 class="section-subheading text-muted">vNEXT is an exciting new consultancy company focused on augmenting human capabilities with AI. We help organisations innovate faster and be more competitive by combining Cloud, DevOps, Data, and AI. We take pride in having the best technologists in the industry. But it's not just about the technology. It’s also about working with our customers to find the right solutions to the right problems.</h3>
-                </div>
-            </div>
             <div class="row">
                 <div class="col-lg-12">
                     <h4 class="careers-heading">Why work at vNEXT?</h4>
                     <p class="text-muted">
                         At vNEXT, we care deeply about our people and we put them first in everything we do. 
-                        Here are some of the reasons why you should work at vNEXT. 
+                        Here are some of the reasons to work at vNEXT. 
                     </p>
                     <ul>
                         <li>A generous salary package.</li>
@@ -29,24 +20,3 @@
                 </div>
             </div>
 
-            <div class="row">
-                <div class="col-lg-12">
-                    <h4 class="careers-heading">Open Roles</h4>
-                    <ul>
-                         <li>Azure Engineer</li>
-                    </ul>
-                </div>
-            </div>
-
-            <div class="row">
-                    <div class="col-lg-12">
-                        <h4 class="careers-heading">Interested?</h4>
-                        <ul>
-                             <li>Please reach us at <a href="mailto:jobs@vnext.com.au?subject=website_jobs_enquiry">jobs@vnext.com.au</a></li>
-                        </ul>
-                    </div>
-                </div>
-
-
-        </div>
-    </section>

--- a/_layouts/careers.html
+++ b/_layouts/careers.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+
+  {% include head.html %}
+
+  <body id="page-top" class="index">
+  
+    {% include careers-page-header.html %}
+
+    {% include careers-page-body.html %}      
+
+    {% include js.html %}
+
+  </body>
+
+</html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,7 @@
 
   {% include header.html %}
   {% include services.html %}
-  {% include careers.html %}  
+  {% include careers-home.html %}  
   {% include team.html %}
   {% include contact.html %}
   {% include footer.html %}

--- a/_plugins/data_page_generator.rb
+++ b/_plugins/data_page_generator.rb
@@ -1,0 +1,154 @@
+# coding: utf-8
+# Generate pages from individual records in yml files
+# (c) 2014-2016 Adolfo Villafiorita
+# Distributed under the conditions of the MIT License
+
+module Jekyll
+
+    module Sanitizer
+      # strip characters and whitespace to create valid filenames, also lowercase
+      def sanitize_filename(name)
+        if(name.is_a? Integer)
+          return name.to_s
+        end
+        return name.tr(
+    "ÀÁÂÃÄÅàáâãäåĀāĂăĄąÇçĆćĈĉĊċČčÐðĎďĐđÈÉÊËèéêëĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħÌÍÎÏìíîïĨĩĪīĬĭĮįİıĴĵĶķĸĹĺĻļĽľĿŀŁłÑñŃńŅņŇňŉŊŋÑñÒÓÔÕÖØòóôõöøŌōŎŏŐőŔŕŖŗŘřŚśŜŝŞşŠšſŢţŤťŦŧÙÚÛÜùúûüŨũŪūŬŭŮůŰűŲųŴŵÝýÿŶŷŸŹźŻżŽž",
+    "AAAAAAaaaaaaAaAaAaCcCcCcCcCcDdDdDdEEEEeeeeEeEeEeEeEeGgGgGgGgHhHhIIIIiiiiIiIiIiIiIiJjKkkLlLlLlLlLlNnNnNnNnnNnNnOOOOOOooooooOoOoOoRrRrRrSsSsSsSssTtTtTtUUUUuuuuUuUuUuUuUuUuWwYyyYyYZzZzZz"
+  ).downcase.strip.gsub(' ', '-').gsub(/[^\w.-]/, '')
+      end
+    end
+  
+    # this class is used to tell Jekyll to generate a page
+    class DataPage < Page
+      include Sanitizer
+  
+      # - site and base are copied from other plugins: to be honest, I am not sure what they do
+      #
+      # - `index_files` specifies if we want to generate named folders (true) or not (false)
+      # - `dir` is the default output directory
+      # - `data` is the data defined in `_data.yml` of the record for which we are generating a page
+      # - `name` is the key in `data` which determines the output filename
+      # - `name_expr` is an expression for generating the output filename
+      # - `template` is the name of the template for generating the page
+      # - `extension` is the extension for the generated file
+      def initialize(site, base, index_files, dir, data, name, name_expr, template, extension)
+        @site = site
+        @base = base
+  
+        # @dir is the directory where we want to output the page
+        # @name is the name of the page to generate
+        # @name_expr is an expression for generating the name of the page
+        #
+        # the value of these variables changes according to whether we
+        # want to generate named folders or not
+        if name_expr
+          record = data
+          raw_filename = eval(name_expr)
+          if raw_filename == nil
+            puts "error (datapage_gen). name_expr '#{name_expr}' generated an empty value in record #{data}"
+            return
+          end
+        else
+          raw_filename = data[name]
+          if raw_filename == nil
+            puts "error (datapage_gen). empty value for field '#{name}' in record #{data}"
+            return
+          end
+        end
+  
+        filename = sanitize_filename(raw_filename).to_s
+  
+        @dir = dir + (index_files ? "/" + filename + "/" : "")
+        @name = (index_files ? "index" : filename) + "." + extension.to_s
+  
+        self.process(@name)
+        self.read_yaml(File.join(base, '_layouts'), template + ".html")
+        self.data['title'] = raw_filename
+        # add all the information defined in _data for the current record to the
+        # current page (so that we can access it with liquid tags)
+  
+        if data.key?('name')
+          data['_name'] = data['name']
+        end
+  
+        self.data.merge!(data)
+      end
+    end
+  
+    class DataPagesGenerator < Generator
+      safe true
+  
+      # generate loops over _config.yml/page_gen invoking the DataPage
+      # constructor for each record for which we want to generate a page
+  
+      def generate(site)
+        # page_gen_dirs determines whether we want to generate index pages
+        # (name/index.html) or standard files (name.html). This information
+        # is passed to the DataPage constructor, which sets the @dir variable
+        # as required by this directive
+        index_files = site.config['page_gen-dirs'] == true
+  
+        # data contains the specification of the data for which we want to generate
+        # the pages (look at the README file for its specification)
+        data = site.config['page_gen']
+        if data
+          data.each do |data_spec|
+            index_files_for_this_data = data_spec['index_files'] != nil ? data_spec['index_files'] : index_files
+            template = data_spec['template'] || data_spec['data']
+            name = data_spec['name']
+            name_expr = data_spec['name_expr']
+            dir = data_spec['dir'] || data_spec['data']
+            extension = data_spec['extension'] || "html"
+  
+            if site.layouts.key? template
+              # records is the list of records defined in _data.yml
+              # for which we want to generate different pages
+              records = nil
+              data_spec['data'].split('.').each do |level|
+                if records.nil?
+                  records = site.data[level]
+                else
+                  records = records[level]
+                end
+              end
+  
+              # apply filtering conditions:
+              # - filter requires the name of a boolean field
+              # - filter_condition evals a ruby expression
+              records = records.select { |r| r[data_spec['filter']] } if data_spec['filter']
+              records = records.select { |record| eval(data_spec['filter_condition']) } if data_spec['filter_condition']
+  
+              records.each do |record|
+                site.pages << DataPage.new(site, site.source, index_files_for_this_data, dir, record, name, name_expr, template, extension)
+              end
+            else
+              puts "error (datapage_gen). could not find template #{template}" if not site.layouts.key? template
+            end
+          end
+        end
+      end
+    end
+  
+    module DataPageLinkGenerator
+      include Sanitizer
+  
+      # use it like this: {{input | datapage_url: dir}}
+      # to generate a link to a data_page.
+      #
+      # the filter is smart enough to generate different link styles
+      # according to the data_page-dirs directive ...
+      #
+      # ... however, the filter is not smart enough to support different
+      # extensions for filenames.
+      #
+      # Thus, if you use the `extension` feature of this plugin, you
+      # need to generate the links by hand
+      def datapage_url(input, dir)
+        extension = Jekyll.configuration({})['page_gen-dirs'] ? '/' : '.html'
+        "#{dir}/#{sanitize_filename(input)}#{extension}"
+      end
+    end
+  
+  end
+  
+  Liquid::Template.register_filter(Jekyll::DataPageLinkGenerator)


### PR DESCRIPTION
- Uses jekyll `page generator` from [here](https://github.com/avillafiorita/jekyll-datapage_gen)
- Creates career detail pages, e.g. `https://www.vnext.com.au/jobs/azure-engineer/`
  - dynamically based on data in the `_data\careers.yml` file
- Extracts out common bits (but more can be done)